### PR TITLE
prepend and append comment elements instead inserting them inside <w:r>

### DIFF
--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -73,8 +73,8 @@ class CT_R(BaseOxmlElement):
         rStart._id = _id
         rEnd = OxmlElement('w:commentRangeEnd')
         rEnd._id = _id
-        self.insert(0,rStart)
-        self.append(rEnd)
+        self.addprevious(rStart)
+        self.addnext(rEnd)
 
     def add_comment_reference(self, _id):
         reference = OxmlElement('w:commentReference')


### PR DESCRIPTION
At this moment commenting whole text for particular run highlights only last letter of given run instead of whole text.

code sample to reproduce issue: 

```python
from docx import Document

doc = Document()

p = doc.add_paragraph('It should not be commented ')
run = p.add_run('This should be commented ')
run.add_comment('2nd run comment', author='Albert Kisiel', initials= 'AK')
run2 = p.add_run("It should not be commented too")

doc.save('test.docx')
```

What is expected: `This should be commented ` should be highlighted/marked as commented text
Current behaviour: only last character of string `This should be commented ` is highlighted/marked as commented text


Explanation:  Current version of this package will insert `w:commentRangeStart` and `w:commentRangeEnd` elements inside `w:r` element which is intended to be commented. Correct ways is to prepend `w:r` element with `w:commentRangeStart` and append with `w:commentRangeEnd`