### PR TITLE
Create add_ole_object_to_run func

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.2.14' 
+__version__ = '0.2.15' 
 
 
 # register custom Part classes with opc package reader

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.2.15' 
+__version__ = '0.2.14' 
 
 
 # register custom Part classes with opc package reader


### PR DESCRIPTION
OLE Object is contained and wrapped in a run and represented in the Word file as an image, the function tend to add the object from the disc to the run and link it the Document package via Document's Relationships